### PR TITLE
Toy-22 사진 크기 조절 및 회전 기능 구현(촬영 사진)

### DIFF
--- a/app/src/main/java/kr/co/yogiyo/rookiephotoapp/BaseActivity.java
+++ b/app/src/main/java/kr/co/yogiyo/rookiephotoapp/BaseActivity.java
@@ -6,6 +6,13 @@ import android.widget.Toast;
 public class BaseActivity extends AppCompatActivity {
 
 
+    protected static final int EDIT_SELECTED_PHOTO = 0;
+    protected static final int EDIT_CAPTURED_PHOTO = 1;
+
+
+
+
+
     protected void showToast(String toastMessage) {
         Toast.makeText(this, toastMessage, Toast.LENGTH_LONG).show();
     }

--- a/app/src/main/java/kr/co/yogiyo/rookiephotoapp/camera/capture/PreviewActivity.java
+++ b/app/src/main/java/kr/co/yogiyo/rookiephotoapp/camera/capture/PreviewActivity.java
@@ -1,16 +1,28 @@
 package kr.co.yogiyo.rookiephotoapp.camera.capture;
 
+import android.Manifest;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.MediaStore;
+import android.support.v4.app.ActivityCompat;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 
+import java.io.ByteArrayOutputStream;
+
 import kr.co.yogiyo.rookiephotoapp.BaseActivity;
 import kr.co.yogiyo.rookiephotoapp.R;
+import kr.co.yogiyo.rookiephotoapp.edit.EditPhotoActivity;
 
 public class PreviewActivity extends BaseActivity implements View.OnClickListener {
 
+    private static final int REQUEST_STORAGE_WRITE_ACCESS_PERMISSION = 102;
 
     private ImageView previewImageView;
     private Button backButton;
@@ -65,6 +77,7 @@ public class PreviewActivity extends BaseActivity implements View.OnClickListene
                 break;
             case R.id.btn_edit:
                 // 편집화면으로 이동
+                editCapturedPhoto();
                 break;
         }
 
@@ -73,6 +86,33 @@ public class PreviewActivity extends BaseActivity implements View.OnClickListene
     private static float getApproximateFileMegabytes(Bitmap bitmap) {
         return (bitmap.getRowBytes() * bitmap.getHeight()) / 1024 / 1024;
 
+    }
+
+    private void editCapturedPhoto() {
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
+                && ActivityCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    REQUEST_STORAGE_WRITE_ACCESS_PERMISSION);
+        } else {
+            Uri uri = getImageUri(PreviewActivity.this, capturedImageBitmap);
+
+            Intent doStartEditPhotoActivityIntent = new Intent(this, EditPhotoActivity.class);
+            doStartEditPhotoActivityIntent.putExtra(getString(R.string.edit_photo_category_number), EDIT_CAPTURED_PHOTO);
+            doStartEditPhotoActivityIntent.putExtra(getString(R.string.capture_photo_uri), uri);
+            startActivity(doStartEditPhotoActivityIntent);
+            finish();
+        }
+    }
+
+    // Bitmap을 Uri로 변환하는 함수
+    private Uri getImageUri(Context context, Bitmap inImage) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        inImage.compress(Bitmap.CompressFormat.JPEG, 100, bytes);
+        String path = MediaStore.Images.Media.insertImage(context.getContentResolver(), inImage, "Image", null);
+        return Uri.parse(path);
     }
 
 }

--- a/app/src/main/java/kr/co/yogiyo/rookiephotoapp/edit/EditPhotoActivity.java
+++ b/app/src/main/java/kr/co/yogiyo/rookiephotoapp/edit/EditPhotoActivity.java
@@ -23,11 +23,8 @@ public class EditPhotoActivity extends BaseActivity {
 
     private static final String TAG = EditPhotoActivity.class.getSimpleName();
 
-    public static final int EDIT_SELECTED_PHOTO = 0;
-    public static final int EDIT_CAPTURED_PHOTO = 1;
-
-    private static final int REQUEST_PICK_GALLERY = 123;
     private static final int REQUEST_STORAGE_READ_ACCESS_PERMISSION = 101;
+    private static final int REQUEST_PICK_GALLERY = 123;
 
     private static final String SAMPLE_CROPPED_IMAGE_NAME = "SampleCropImage";
 


### PR DESCRIPTION
#### 1. EditPhotoActivity와 PreviewActivity에 공통적으로 쓰이는 상수를 BaseActivity에 작성했습니다
 - Intent 구별 인덱스 (EDIT_SELECTED_PHOTO/EDIT_CAPTURED_PHOTO)

#### 2. PreviewActivity에서 편집버튼을 클릭하면 촬영한 사진이 편집 모드로 변경될 수 있게 구현했습니다
- UCrop 라이브러리에 Uri를 넘겨줘야 하기 때문에 Bitmp에서 Uri로 변환하는 코드 추가하였고,
- Intent로 촬영한 사진을 구별할 수 있는 인텐트를 같이 넘기면서 액티비티를 띄우게 하였습니다