### PR TITLE
TOY-32 Glide와 setImageURI 혼용시 setImageURI 무시되는 문제 해결

### DIFF
--- a/app/src/main/java/kr/co/yogiyo/rookiephotoapp/diary/DiaryEditActivity.java
+++ b/app/src/main/java/kr/co/yogiyo/rookiephotoapp/diary/DiaryEditActivity.java
@@ -8,10 +8,10 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
@@ -22,7 +22,10 @@ import android.widget.TextView;
 import android.widget.TimePicker;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
+import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.target.Target;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -191,7 +194,10 @@ public class DiaryEditActivity extends BaseActivity implements View.OnClickListe
             } else if (getIntent().getData() != null) {
                 Uri uri = getIntent().getData();
                 selectedUri = uri;
-                editPhotoImageButton.setImageURI(uri);
+                Glide.with(this)
+                        .load(selectedUri)
+                        .skipMemoryCache(true)
+                        .into(editPhotoImageButton);
                 GlobalApplication.getGlobalApplicationContext().setFromDiary(true);
             }
         } else {
@@ -205,8 +211,6 @@ public class DiaryEditActivity extends BaseActivity implements View.OnClickListe
                             photoFileName = diary.getImage();
                             Glide.with(DiaryEditActivity.this)
                                     .load(Constants.YOGIDIARY_PATH + File.separator + photoFileName)
-                                    .error(ContextCompat.getDrawable(DiaryEditActivity.this, R.mipmap.diary_photo_add))
-                                    .diskCacheStrategy(DiskCacheStrategy.NONE)
                                     .skipMemoryCache(true)
                                     .into(editPhotoImageButton);
                             editDescriptionTextView.setText(diary.getDescription());
@@ -271,20 +275,33 @@ public class DiaryEditActivity extends BaseActivity implements View.OnClickListe
             case RESULT_OK:
                 if ((requestCode == Constants.REQUEST_DIARY_PICK_GALLERY || requestCode == Constants.REQUEST_DIARY_CAPTURE_PHOTO) && data != null) {
                     selectedUri = data.getData();
-                    if (selectedUri != null) {
-                        editPhotoImageButton.setImageURI(null);
-                        editPhotoImageButton.setImageURI(selectedUri);
-                        isPhotoUpdate = true;
-                    } else {
-                        showToast(R.string.toast_cannot_retrieve_selected_image);
-                    }
+                    Glide.with(DiaryEditActivity.this)
+                            .load(selectedUri)
+                            .skipMemoryCache(true)
+                            .listener(new RequestListener<Drawable>() {
+                                @Override
+                                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
+                                    showToast(R.string.toast_cannot_retrieve_selected_image);
+                                    return false;
+                                }
+
+                                @Override
+                                public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
+                                    isPhotoUpdate = true;
+                                    return false;
+                                }
+                            })
+                            .into(editPhotoImageButton);
                 }
                 break;
             case Constants.RESULT_CAPTURED_PHOTO:
                 if ((requestCode == Constants.REQUEST_DIARY_CAPTURE_PHOTO) && data != null) {
                     isBitmap = true;
                     selectedBitmap = loadBitmapFromInternalStorage(getApplicationContext());
-                    editPhotoImageButton.setImageBitmap(selectedBitmap);
+                    Glide.with(DiaryEditActivity.this)
+                            .load(selectedBitmap)
+                            .skipMemoryCache(true)
+                            .into(editPhotoImageButton);
                     isPhotoUpdate = true;
                 }
                 break;

--- a/app/src/main/java/kr/co/yogiyo/rookiephotoapp/diary/DiaryEditActivity.java
+++ b/app/src/main/java/kr/co/yogiyo/rookiephotoapp/diary/DiaryEditActivity.java
@@ -23,6 +23,7 @@ import android.widget.TimePicker;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
@@ -120,7 +121,6 @@ public class DiaryEditActivity extends BaseActivity implements View.OnClickListe
         editDescriptionTextView.setOnClickListener(this);
     }
 
-
     @Override
     public void onClick(View v) {
         switch (v.getId()) {
@@ -188,6 +188,7 @@ public class DiaryEditActivity extends BaseActivity implements View.OnClickListe
                 selectedBitmap = PreviewActivity.capturedImageBitmap;
                 Glide.with(this)
                         .load(selectedBitmap)
+                        .diskCacheStrategy(DiskCacheStrategy.NONE)
                         .skipMemoryCache(true)
                         .into(editPhotoImageButton);
 
@@ -196,6 +197,7 @@ public class DiaryEditActivity extends BaseActivity implements View.OnClickListe
                 selectedUri = uri;
                 Glide.with(this)
                         .load(selectedUri)
+                        .diskCacheStrategy(DiskCacheStrategy.NONE)
                         .skipMemoryCache(true)
                         .into(editPhotoImageButton);
                 GlobalApplication.getGlobalApplicationContext().setFromDiary(true);
@@ -211,6 +213,7 @@ public class DiaryEditActivity extends BaseActivity implements View.OnClickListe
                             photoFileName = diary.getImage();
                             Glide.with(DiaryEditActivity.this)
                                     .load(Constants.YOGIDIARY_PATH + File.separator + photoFileName)
+                                    .diskCacheStrategy(DiskCacheStrategy.NONE)
                                     .skipMemoryCache(true)
                                     .into(editPhotoImageButton);
                             editDescriptionTextView.setText(diary.getDescription());
@@ -277,6 +280,7 @@ public class DiaryEditActivity extends BaseActivity implements View.OnClickListe
                     selectedUri = data.getData();
                     Glide.with(DiaryEditActivity.this)
                             .load(selectedUri)
+                            .diskCacheStrategy(DiskCacheStrategy.NONE)
                             .skipMemoryCache(true)
                             .listener(new RequestListener<Drawable>() {
                                 @Override
@@ -300,6 +304,7 @@ public class DiaryEditActivity extends BaseActivity implements View.OnClickListe
                     selectedBitmap = loadBitmapFromInternalStorage(getApplicationContext());
                     Glide.with(DiaryEditActivity.this)
                             .load(selectedBitmap)
+                            .diskCacheStrategy(DiskCacheStrategy.NONE)
                             .skipMemoryCache(true)
                             .into(editPhotoImageButton);
                     isPhotoUpdate = true;

--- a/app/src/main/java/kr/co/yogiyo/rookiephotoapp/gallery/GalleryAdapter.java
+++ b/app/src/main/java/kr/co/yogiyo/rookiephotoapp/gallery/GalleryAdapter.java
@@ -11,6 +11,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
 import java.io.File;
 import java.util.List;
@@ -41,6 +42,8 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.GalleryV
     public void onBindViewHolder(@NonNull final GalleryViewHolder galleryViewHolder, int i) {
         Glide.with(context)
                 .load(imagePaths.get(i))
+                .diskCacheStrategy(DiskCacheStrategy.NONE)
+                .skipMemoryCache(true)
                 .into(galleryViewHolder.imageView);
         FrameLayout selectedFrame = galleryViewHolder.selectedFrame;
 


### PR DESCRIPTION
코드 리뷰 부탁드립니다.

TOY-32 백업/복원 코드를 작성하면서 일부 이미지 뷰 부분을 Glide로 바꾸는 작업을 했었는데,

한 액티비티에서 Glide로 한 번 이미지를 그려주고 나서
setImageURI를 호출해도 이미지가 교체되지 않는 이슈가 있어서 수정했습니다.