### PR TITLE
TOY-24 다이어리 및 갤러리 버튼 setVisibility 분리, 뒤로가기 버튼 조건문 추가

### DIFF
--- a/app/src/main/java/kr/co/yogiyo/rookiephotoapp/camera/CameraActivity.kt
+++ b/app/src/main/java/kr/co/yogiyo/rookiephotoapp/camera/CameraActivity.kt
@@ -79,7 +79,8 @@ class CameraActivity : BaseActivity() {
             btn_capture_size.hasFocus() -> btn_capture_size.clearFocus()
             else -> {
                 backPressedStartTime = Calendar.getInstance().timeInMillis.also {
-                    if (it - backPressedStartTime < 2000) {
+                    if (it - backPressedStartTime < 2000 ||
+                            GlobalApplication.globalApplicationContext.isFromDiary) {
                         super.onBackPressed()
                     } else {
                         showSnackbar(relative_root, getString(R.string.text_finish_snackbar))
@@ -90,10 +91,6 @@ class CameraActivity : BaseActivity() {
     }
 
     private fun initView() {
-        if (GlobalApplication.globalApplicationContext.isFromDiary) {
-            btn_go_diary.visibility = View.INVISIBLE
-            relative_go_gallery.visibility = View.INVISIBLE
-        }
 
         btn_go_diary.setOnClickListener {
             val intent = Intent(this, DiariesActivity::class.java)

--- a/app/src/main/java/kr/co/yogiyo/rookiephotoapp/camera/CameraViewModel.kt
+++ b/app/src/main/java/kr/co/yogiyo/rookiephotoapp/camera/CameraViewModel.kt
@@ -11,6 +11,7 @@ import android.support.v4.content.ContextCompat
 import android.view.View
 import com.otaliastudios.cameraview.Flash
 import com.otaliastudios.cameraview.Grid
+import kr.co.yogiyo.rookiephotoapp.GlobalApplication
 import kr.co.yogiyo.rookiephotoapp.R
 
 class CameraViewModel(private val context: Context) : BaseObservable() {
@@ -27,6 +28,8 @@ class CameraViewModel(private val context: Context) : BaseObservable() {
     val delayVisibility: ObservableInt = ObservableInt(View.GONE)
     val delayMessageLabel: ObservableInt = ObservableInt(0)
     val frameControlButtonVisibility: ObservableInt = ObservableInt(View.VISIBLE)
+    val goDiaryButtonVisibility: ObservableInt = ObservableInt(View.VISIBLE)
+    val goGalleryButtonVisibility: ObservableInt = ObservableInt(View.VISIBLE)
     val showMoreLayoutVisibility: ObservableInt = ObservableInt(View.GONE)
     val showCaptureSizeLayoutVisibility: ObservableInt = ObservableInt(View.GONE)
     val textColorByCaptureSize: ObservableInt = ObservableInt(ContextCompat.getColor(context, android.R.color.black))
@@ -103,6 +106,8 @@ class CameraViewModel(private val context: Context) : BaseObservable() {
 
             timerHandler.postDelayed(makeDecrementTimerFunction(++currentCaptureID), 1000)
             frameControlButtonVisibility.set(View.GONE)
+            goDiaryButtonVisibility.set(View.GONE)
+            goGalleryButtonVisibility.set(View.GONE)
         } else {
             captureNow()
         }
@@ -129,6 +134,13 @@ class CameraViewModel(private val context: Context) : BaseObservable() {
         frameControlButtonVisibility.set(View.VISIBLE)
         showMoreLayoutVisibility.set(View.GONE)
         showCaptureSizeLayoutVisibility.set(View.GONE)
+        if(GlobalApplication.globalApplicationContext.isFromDiary){
+            goDiaryButtonVisibility.set(View.INVISIBLE)
+            goGalleryButtonVisibility.set(View.INVISIBLE)
+        } else {
+            goDiaryButtonVisibility.set(View.VISIBLE)
+            goGalleryButtonVisibility.set(View.VISIBLE)
+        }
     }
 
     fun timerCancel(): Boolean {

--- a/app/src/main/java/kr/co/yogiyo/rookiephotoapp/camera/CameraViewModel.kt
+++ b/app/src/main/java/kr/co/yogiyo/rookiephotoapp/camera/CameraViewModel.kt
@@ -134,13 +134,16 @@ class CameraViewModel(private val context: Context) : BaseObservable() {
         frameControlButtonVisibility.set(View.VISIBLE)
         showMoreLayoutVisibility.set(View.GONE)
         showCaptureSizeLayoutVisibility.set(View.GONE)
-        if(GlobalApplication.globalApplicationContext.isFromDiary){
-            goDiaryButtonVisibility.set(View.INVISIBLE)
-            goGalleryButtonVisibility.set(View.INVISIBLE)
+        goDiaryButtonVisibility.set(if (GlobalApplication.globalApplicationContext.isFromDiary) {
+            View.INVISIBLE
         } else {
-            goDiaryButtonVisibility.set(View.VISIBLE)
-            goGalleryButtonVisibility.set(View.VISIBLE)
-        }
+            View.VISIBLE
+        })
+        goGalleryButtonVisibility.set(if (GlobalApplication.globalApplicationContext.isFromDiary) {
+            View.INVISIBLE
+        } else {
+            View.VISIBLE
+        })
     }
 
     fun timerCancel(): Boolean {

--- a/app/src/main/res/layout/activity_camera.xml
+++ b/app/src/main/res/layout/activity_camera.xml
@@ -74,7 +74,7 @@
             android:alpha="@{viewModel.alphaByCaptureSize}"
             android:background="?selectableItemBackgroundBorderless"
             android:src="@{viewModel.goDiaryButtonSrc}"
-            android:visibility="@{viewModel.frameControlButtonVisibility}" />
+            android:visibility="@{viewModel.goDiaryButtonVisibility}" />
 
         <RelativeLayout
             android:id="@+id/relative_go_gallery"
@@ -86,7 +86,7 @@
             android:layout_marginBottom="24dp"
             android:clickable="true"
             android:focusable="true"
-            android:visibility="@{viewModel.frameControlButtonVisibility}">
+            android:visibility="@{viewModel.goGalleryButtonVisibility}">
 
             <ImageButton
                 android:id="@+id/btn_go_gallery"


### PR DESCRIPTION
코드 리뷰 부탁드립니다.

1. 다이어리 추가/편집 화면에서 이미지를 위해 사진 촬영 기능으로 이동할 때
다이어리 및 갤러리 버튼의 VISIBILITY Observable 코드를 다른 컨트롤 버튼과 분리했습니다.

2. 카메라의 뒤로 가기 버튼을 두 번 눌러야 하는 상황은
카메라 앱 아래 다른 액티비티 스택이 없을 때만 발생하도록 분기문을 추가했습니다.