### PR TITLE
TOY-65 다이어리 편집 화면에서 저장 로직의 문제 &  추가/편집화면에서 회전 안되게 설정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,9 +51,11 @@
             android:theme="@style/Theme.FDB32D" />
         <activity
             android:name=".diary.DiaryEditActivity"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
         <activity
             android:name=".diary.DiaryDetailActivity"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
     </application>
 

--- a/app/src/main/java/kr/co/yogiyo/rookiephotoapp/diary/DiaryEditActivity.java
+++ b/app/src/main/java/kr/co/yogiyo/rookiephotoapp/diary/DiaryEditActivity.java
@@ -291,6 +291,7 @@ public class DiaryEditActivity extends BaseActivity implements View.OnClickListe
                                 @Override
                                 public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
                                     isPhotoUpdate = true;
+                                    isBitmap = false;
                                     return false;
                                 }
                             })


### PR DESCRIPTION
1. 다이어리 편집 페이지에서 이미지 설정을 할 시,사진 촬영을 한 후 적용하였다가 사진 선택으로 변경하여 글을 등록하는 경우, 이전에 촬영한 사진이 저장되는 것을 수정하였습니다

2. 다이어리 편집 페이지 회전 안되게 하기
카메라 영역이 현재 회전이 안되게 구현되어 있어 통일성을 맞추었습니다